### PR TITLE
Remove npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-tag-version-prefix=""


### PR DESCRIPTION
npm refused to care about my version prefix, so I'm just going to give in and let it prefix my versions with a "v"