### PR TITLE
Allow fetching by document ref

### DIFF
--- a/source/fetch/index.js
+++ b/source/fetch/index.js
@@ -4,13 +4,14 @@ export default ({
   repository,
   type,
   single,
-  order = []
+  order = [],
+  token
 }) => {
   const orderings = order.map(({ field, asc }) => `my.${type}.${field}${asc ? ' desc' : ''}`)
 
   return Prismic.api(`https://${repository}.cdn.prismic.io/api`).then((Api) => (
     Api.form('everything')
-      .ref(Api.master())
+      .ref(token || Api.master())
       .query([
         Prismic.Predicates.at('document.type', type)
       ])


### PR DESCRIPTION
Uses a token string due to Prismic providing refs under the URL parameter `token`