### PR TITLE
Topic/default slice value

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prismic-utils",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "description": "A collection of functions for parsing data from a Prismic CMS",
   "main": "dist/index.js",
   "scripts": {

--- a/source/deserialize/index.js
+++ b/source/deserialize/index.js
@@ -55,7 +55,11 @@ const deserializeField = (prismicDoc, { key, type }, options = {}) => {
     case 'SliceZone':
       const { slices = [] } = prismicDoc.getSliceZone(key) || {}
       return slices.map((slice) => {
-        const { value } = slice.value
+        // get the nested group values, or just set the slice.value if not a group
+        const {
+          value = slice.value
+        } = slice.value
+
         const deserializedValue = Array.isArray(value) ? (
           value.map((doc) => deserializeDocument(doc))
         ) : value

--- a/source/deserialize/index.js
+++ b/source/deserialize/index.js
@@ -91,7 +91,7 @@ const mapFieldTypesToArray = ({
   ...props
 }) => {
   // add document level fields
-  const documentFields = reduce(['id', 'uid'], (fields, field) => (
+  const documentFields = reduce(['id', 'uid', 'tags'], (fields, field) => (
     props[field] ? (
       fields.concat({
         key: field,


### PR DESCRIPTION
If slice isn't a group, we just want to return the raw value as we can't property deserialize it. Problem was that it should be reading from slice.value rather than slice.value.value (as it does when it is a group)