### PR TITLE
Lock down the Prismic.io version a little tighter

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "lodash": "^4.17.2",
-    "prismic.io": "^3.3.0",
+    "prismic.io": "~3.3.0",
     "sinon": "^1.17.7",
     "striptags": "^2.1.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prismic-utils",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "A collection of functions for parsing data from a Prismic CMS",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
- Minor version bump on prismic.io caused a breaking change
- data['page.field-name'] became data.page.name
- Deserializer uses this data object to build out object, meaning
  documents were not being deserialized properly
- Will add an issue to move back onto latest, but time is poor