### PR TITLE
Exclude tests from build

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A collection of functions for parsing data from a Prismic CMS",
   "main": "dist/index.js",
   "scripts": {
-    "build": "babel source -d dist",
+    "build": "babel source -d dist --ignore '**/__tests__/*'",
     "test:lint": "standard -d source",
     "test:unit": "mocha source/**/**/__tests__/*.js --compilers js:babel-register",
     "test": "npm run test:lint && npm run test:unit",


### PR DESCRIPTION
Fixes issues where projects that don't use all the features of Prismic Utils fail when running their unit tests (e.g. a project that doesn't use the Redux Store features)