### PR TITLE
[BREAKING-CHANGE] Retun all image views and properties

### DIFF
--- a/source/deserialize/index.js
+++ b/source/deserialize/index.js
@@ -83,7 +83,12 @@ const deserializeField = (prismicDoc, { key, type }, options = {}) => {
 
     case 'Image':
       const image = prismicDoc.getImage(key)
-      return image && image.url
+      const { views = {} } = image
+
+      return image && {
+        main: image.main,
+        ...views
+      }
 
     case 'Color':
       return prismicDoc.getColor(key)


### PR DESCRIPTION
Prismic supports multiple image "views" per actual image (think thumbnails, appropriate device sizes, etc). Currently we return only one, the "main" (an ever present type). This change proposes returning all image sizes within an image object, along with their associated metadata (in particular, this fixes #17 so we can have alt text).