### PR TITLE
Parse Prismic Dates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prismic-utils",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "A collection of functions for parsing data from a Prismic CMS",
   "main": "dist/index.js",
   "scripts": {

--- a/source/deserialize/__tests__/index.js
+++ b/source/deserialize/__tests__/index.js
@@ -21,6 +21,11 @@ describe ('Deserialize', () => {
     expect(page.count).to.eql(50)
   })
 
+  it ('should deserialize a date field', () => {
+    const page = deserializeDocument(doc)
+    expect(page.date).to.eql('2017-01-01T00:00:00.000Z')
+  })
+
   it ('should deserialize a timestamp field', () => {
     const page = deserializeDocument(doc)
     expect(page.timestamp).to.eql('2017-01-01T00:00:00.000Z')

--- a/source/deserialize/index.js
+++ b/source/deserialize/index.js
@@ -97,6 +97,10 @@ const deserializeField = (prismicDoc, { key, type }, options = {}) => {
       const video = prismicDoc.get(key)
       return video && video.asHtml()
 
+    case 'Date':
+      const date = prismicDoc.get(key)
+      return date && date.value && date.value.toISOString()
+
     case 'Timestamp':
       const timestamp = prismicDoc.get(key)
       return timestamp && timestamp.value && timestamp.value.toISOString()

--- a/test/prismic.js
+++ b/test/prismic.js
@@ -23,6 +23,10 @@ module.exports = function () {
           }
         ]
       },
+      'page.date': {
+        type: 'Date',
+        value: '2017-01-01'
+      },
       'page.timestamp': {
         type: 'Timestamp',
         value: '2017-01-01T00:00:00+0000'
@@ -59,6 +63,10 @@ module.exports = function () {
               type: 'heading1'
             }
           ]
+        },
+        date: {
+          type: 'Date',
+          value: '2017-01-01'
         },
         timestamp: {
           type: 'Timestamp',


### PR DESCRIPTION
Previously we were only supporting parsing timestamps, not basic dates.