### PR TITLE
Ability in action creator to fetch the token from the store

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prismic-utils",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "A collection of functions for parsing data from a Prismic CMS",
   "main": "dist/index.js",
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -106,6 +106,7 @@ dispatch(createDocumentsAction('page', options))
 - `pages/FETCH` when the request is being fired off
 - `pages/FETCH_SUCCESS` when the request is fulfilled, with the data key of the payload containing the found documents
 - `pages/FETCH_FAILURE` if there was an error during the request
+- `token` can be an actual token, or you can pass in a function that will be called with the redux store, so you can retrieve your token from your store
 
 `options`: additional options that will be used by fetchDocuments
 

--- a/source/action/__tests__/action-test.js
+++ b/source/action/__tests__/action-test.js
@@ -19,7 +19,8 @@ describe('Create Document Action', () => {
 
     dispatch = (action) => {
       spy = sinon.spy()
-      return action(spy)
+      const getState = () => ({ prismic: { token: 'STORE_TOKEN' } })
+      return action(spy, getState)
     }
   })
 
@@ -101,6 +102,34 @@ describe('Create Document Action', () => {
         assert.equal(action.payload.data.length, 2)
         assert.deepEqual(action.payload.data[0], { foo: 'bar' })
         assert.deepEqual(action.payload.data[1], { foo: 'baz' })
+        done()
+      })
+  })
+
+  it('will pass in a basic API token', (done) => {
+    fetchSingle.restore()
+    const fetchStub = sinon.stub(fetch, 'fetchDocument').callsFake(() => {
+      return Promise.resolve({})
+    })
+
+    dispatch(createDocumentAction('page', { token: 'STRING_TOKEN' }))
+      .then((data) => {
+        const args = fetchStub.firstCall.args[0]
+        assert.equal(args.token, 'STRING_TOKEN')
+        done()
+      })
+  })
+
+  it('will grab a token out of the store', (done) => {
+    fetchSingle.restore()
+    const fetchStub = sinon.stub(fetch, 'fetchDocument').callsFake(() => {
+      return Promise.resolve({})
+    })
+
+    dispatch(createDocumentAction('page', { token: (state) => state.prismic.token }))
+      .then((data) => {
+        const args = fetchStub.firstCall.args[0]
+        assert.equal(args.token, 'STORE_TOKEN')
         done()
       })
   })

--- a/source/action/index.js
+++ b/source/action/index.js
@@ -17,7 +17,7 @@ const defaultHandleFailure = (c, error) => ({
   payload: { error }
 })
 
-export const createDocumentsAction = (namespace, options = {}) => (dispatch) => {
+export const createDocumentsAction = (namespace, options = {}) => (dispatch, getState) => {
   const c = {
     FETCH: `${namespace}/FETCH`,
     FETCH_SUCCESS: `${namespace}/FETCH_SUCCESS`,
@@ -29,12 +29,16 @@ export const createDocumentsAction = (namespace, options = {}) => (dispatch) => 
     handleFetch = defaultHandleFetch,
     handleFetchSuccess = defaultHandleSuccess,
     handleFetchFailure = defaultHandleFailure,
+    token,
     ...params
   } = options
 
   dispatch(handleFetch(c))
 
-  return fetch(params)
+  return fetch({
+    ...params,
+    token: getApiToken(token, getState())
+  })
     .then((data) => {
       dispatch(handleFetchSuccess(c, data))
       return Promise.resolve(data)
@@ -50,4 +54,13 @@ export const createDocumentAction = (namespace, options) => {
     ...options,
     fetch: fetchDocument
   })
+}
+
+const getApiToken = (token, state) => {
+  switch (typeof token) {
+    case 'function':
+      return token(state)
+    default:
+      return token
+  }
 }


### PR DESCRIPTION
When creating an action, the `token` param has been overloaded, so you can now either pass in...

a) the token as you could do previously i.e. a string

b) a function, which is called with your store as the only argument, and you can then grab the token out of it, which is extremely handy when we are saving the preview token to our store

e.g. `createDocumentAction('home', { token: (state) => state.prismic.token })` 
