### PR TITLE
Remove react

### DIFF
--- a/bin/announce
+++ b/bin/announce
@@ -2,13 +2,20 @@
 
 set -eux
 
+PACKAGE_VERSION=$(cat package.json \
+  | grep version \
+  | head -1 \
+  | awk -F: '{ print $2 }' \
+  | sed 's/[",]//g' \
+  | tr -d '[[:space:]]')
+
 curl \
 ${SLACK_WEBHOOK_URL} \
 -X POST \
 -H 'Content-Type: application/json' \
 -d @/dev/stdin <<JSON
 {
-  "text": "Prismic Utils version released :tada:",
+  "text": "Prismic Utils version ${PACKAGE_VERSION} released :tada:",
   "channel": "#edh-profs-dev",
   "username": "Prismic Utils",
   "icon_emoji": ":${SLACK_ANNOUNCE_EMOJI}:"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prismic-utils",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "description": "A collection of functions for parsing data from a Prismic CMS",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -41,8 +41,7 @@
     "prismic-javascript": "^1.4.1",
     "prismic-reactjs": "^0.2.3",
     "react-dom": "^15",
-    "sinon": "^2.3.2",
-    "striptags": "^2.1.1"
+    "sinon": "^2.3.2"
   },
   "standard": {
     "ignore": [

--- a/source/deserialize/__tests__/index.js
+++ b/source/deserialize/__tests__/index.js
@@ -13,12 +13,8 @@ describe('Deserialize', () => {
     assert.equal(document.never_before_seen_property, 'foo')
   })
 
-  it('returns the html for a Rich Text area', () => {
-    assert.equal(data.richText.html, '<h1>Hi, this is a title</h1>')
-  })
-
-  it('returns the raw data for a Rich Text area', () => {
-    assert.equal(data.richText.data, rawDocument.data.richText)
+  it('leaves Rich Text untreated', () => {
+    assert.equal(data.richText, rawDocument.data.richText)
   })
 
   it('leaves Key Text untreated', () => {
@@ -74,7 +70,6 @@ describe('Deserialize', () => {
   })
 
   it('performs on Rich Text in Slices', () => {
-    assert(data.slices[0].items[0].rich.text.html, '<h1>foo</h1>')
-    assert(data.slices[0].items[0].rich.text.data, rawDocument.data.slices[0].items[0]['rich-text'])
+    assert(data.slices[0].items[0].rich.text, rawDocument.data.slices[0].items[0]['rich-text'])
   })
 })

--- a/source/deserialize/index.js
+++ b/source/deserialize/index.js
@@ -2,7 +2,6 @@ import isArray from 'lodash/isArray'
 import set from 'lodash/set'
 import sortBy from 'lodash/sortBy'
 import toPairs from 'lodash/toPairs'
-import { RichText } from 'prismic-dom'
 
 const deserializeDocument = ({ data, ...metadata }, options = { react: true }) => {
   const deserializedFields = deserializeFields(data, options)
@@ -20,17 +19,11 @@ const deserializeFields = (fields, options) => (
   }))
 )
 
-const isRichText = (value) => isArray(value) && value.length > 0 && value[0].type
 const isSlice = (value) => isArray(value) && value.length > 0 && value[0].slice_type
 const isGroup = (value) => isArray(value) && value.length > 0 && !value[0].type
 
 const deserializeField = (value, options) => {
-  if (isRichText(value)) {
-    return {
-      data: value,
-      html: RichText.asHtml(value)
-    }
-  } else if (isSlice(value)) {
+  if (isSlice(value)) {
     return value.map((slice) => ({
       type: slice.slice_type,
       label: slice.slice_label,

--- a/source/utils/__tests__/index.js
+++ b/source/utils/__tests__/index.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 import assert from 'assert'
 import React from 'react'
-import { PrismicRichText } from '..'
+import { PrismicRichText, prismicRichTextAsHTML } from '..'
 import { deserializeDocument } from '../..'
 import rawDocument from '../../../test/prismic.json'
 import Adapter from 'enzyme-adapter-react-15'
@@ -21,10 +21,17 @@ const { data } = document
 describe('PrismicRichText', () => {
   it('allows the returned Rich Text data to be rendered into a React component', () => {
     const { richText } = data
-    const wrapper = mount(<PrismicRichText>{richText.data}</PrismicRichText>)
+    const wrapper = mount(<PrismicRichText>{richText}</PrismicRichText>)
     const heading = wrapper.find('h1')
 
     assert.equal(heading.length, 1)
     assert.equal(heading.text(), 'Hi, this is a title')
+  })
+})
+
+describe('prismicRichTextAsHTML', () => {
+  it('returns the html of a Rich Text area', () => {
+    const { richText } = data
+    assert.equal(prismicRichTextAsHTML(richText), '<h1>Hi, this is a title</h1>')
   })
 })

--- a/source/utils/index.js
+++ b/source/utils/index.js
@@ -1,3 +1,6 @@
-import { RichText } from 'prismic-reactjs'
+import { RichText as ReactRichText } from 'prismic-reactjs'
+import { RichText as HTMLRichText } from 'prismic-dom'
 
-export const PrismicRichText = ({ children }) => RichText.render(children)
+export const PrismicRichText = ({ children }) => ReactRichText.render(children)
+
+export const prismicRichTextAsHTML = (content) => HTMLRichText.asHtml(content)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1255,16 +1255,9 @@ domhandler@^2.3.0:
   dependencies:
     domelementtype "1"
 
-domutils@1.5.1:
+domutils@1.5.1, domutils@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
-  dependencies:
-    dom-serializer "0"
-    domelementtype "1"
-
-domutils@^1.5.1:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.6.2.tgz#1958cc0b4c9426e9ed367fb1c8e854891b0fa3ff"
   dependencies:
     dom-serializer "0"
     domelementtype "1"
@@ -1399,11 +1392,11 @@ es6-weak-map@^2.0.1:
     es6-iterator "^2.0.1"
     es6-symbol "^3.1.1"
 
-escape-string-regexp@1.0.2:
+escape-string-regexp@1.0.2, escape-string-regexp@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz#4dbc2fe674e71949caf3fb2695ce7f2dc1d9a8d1"
 
-escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
+escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
@@ -1966,13 +1959,9 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
-iconv-lite@0.4.13:
+iconv-lite@0.4.13, iconv-lite@~0.4.13:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2"
-
-iconv-lite@~0.4.13:
-  version "0.4.19"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
 
 ignore@^3.0.11, ignore@^3.0.9, ignore@^3.2.0:
   version "3.3.6"
@@ -3275,10 +3264,6 @@ strip-bom@^3.0.0:
 strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
-
-striptags@^2.1.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/striptags/-/striptags-2.2.1.tgz#4c450b708d41b8bf39cf24c49ff234fc6aabfd32"
 
 supports-color@1.2.0:
   version "1.2.0"


### PR DESCRIPTION
**Problem**

We had duplicate, and potential large amounts of data in our store i.e. both `data` and `html` for a rich text field.

**Solution**

Only store the raw data, and provide both a react component helper, and a html helper...

```
import { PrismicRichText } from 'prismic-utils'
...
<PrismicRichText>{myField}</PrismicRichText>
```

```
import { prismicRichTextAsHTML } from 'prismic-utils'
...
prismicRichTextAsHTML(myField)
```