### PR TITLE
Spread fields on the root of the returned object

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prismic-utils",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "A collection of functions for parsing data from a Prismic CMS",
   "main": "dist/index.js",
   "scripts": {

--- a/source/deserialize/__tests__/index.js
+++ b/source/deserialize/__tests__/index.js
@@ -3,14 +3,13 @@ import assert from 'assert'
 import deserializeDocument from '../'
 import rawDocument from '../../../test/prismic.json'
 
-const document = deserializeDocument(rawDocument)
-const { data } = document
+const data = deserializeDocument(rawDocument)
 
 describe('Deserialize', () => {
   it('retains document metadata', () => {
-    assert.equal(document.id, 'document-id')
-    assert.equal(document.uid, 'document-uid')
-    assert.equal(document.never_before_seen_property, 'foo')
+    assert.equal(data.id, 'document-id')
+    assert.equal(data.uid, 'document-uid')
+    assert.equal(data.never_before_seen_property, 'foo')
   })
 
   it('leaves Rich Text untreated', () => {

--- a/source/deserialize/index.js
+++ b/source/deserialize/index.js
@@ -8,7 +8,7 @@ const deserializeDocument = ({ data, ...metadata }, options = { react: true }) =
 
   return {
     ...metadata,
-    data: mapFieldsToObject(deserializedFields)
+    ...mapFieldsToObject(deserializedFields)
   }
 }
 

--- a/source/utils/__tests__/index.js
+++ b/source/utils/__tests__/index.js
@@ -15,8 +15,7 @@ global.navigator = { userAgent: 'node.js' }
 
 Enzyme.configure({ adapter: new Adapter() })
 
-const document = deserializeDocument(rawDocument)
-const { data } = document
+const data = deserializeDocument(rawDocument)
 
 describe('PrismicRichText', () => {
   it('allows the returned Rich Text data to be rendered into a React component', () => {


### PR DESCRIPTION
**Problem**

The returned structure after deserializing had document metadata in the root of the returned object, but was putting all the fields in a `data` key, meaning it was an extra level deep. Which made it hard to easily grab data off the object in our apps.

E.g.

```
{
  uid: 'foo',
  data: {
    myField: 123
  }
}
```

**Solution**

Instead of putting the fields in the `data` key, just spread them on the root.

E.g.

```
{
  uid: 'foo',
  myField: 123
}
```

