### PR TITLE
Remove autocompress from images

### DIFF
--- a/source/deserialize/__tests__/index.js
+++ b/source/deserialize/__tests__/index.js
@@ -20,8 +20,9 @@ describe('Deserialize', () => {
     assert.equal(data.keyText, rawDocument.data.keyText)
   })
 
-  it('leaves Image untreated', () => {
-    assert.deepEqual(data.image, rawDocument.data.image)
+  it.only('returns images, removing the auto compression', () => {
+    assert.equal(data.image.url, rawDocument.data.image.url.replace('auto=compress,format', ''))
+    assert.equal(data.image.alt, rawDocument.data.image.alt)
   })
 
   it('leaves Links untreated', () => {

--- a/source/deserialize/index.js
+++ b/source/deserialize/index.js
@@ -21,6 +21,7 @@ const deserializeFields = (fields, options) => (
 
 const isSlice = (value) => isArray(value) && value.length > 0 && value[0].slice_type
 const isGroup = (value) => isArray(value) && value.length > 0 && !value[0].type
+const isImage = (value = {}) => value.url && value.alt
 
 const deserializeField = (value, options) => {
   if (isSlice(value)) {
@@ -39,6 +40,11 @@ const deserializeField = (value, options) => {
       const deserializedFields = deserializeFields(group, options)
       return mapFieldsToObject(deserializedFields)
     })
+  } else if (isImage(value)) {
+    return {
+      ...value,
+      url: value.url.replace('auto=compress,format', '')
+    }
   } else {
     return value
   }

--- a/test/prismic.json
+++ b/test/prismic.json
@@ -28,7 +28,7 @@
       },
       "alt": "foo bar",
       "copyright": null,
-      "url": "https://wroomdev.s3.amazonaws.com/tutoblanktemplate%2F97109f41-140e-4dc9-a2c8-96fb10f14051_star.gif",
+      "url": "https://wroomdev.s3.amazonaws.com/tutoblanktemplate%2F97109f41-140e-4dc9-a2c8-96fb10f14051_star.gif?auto=compress,format",
       "mobile": {
         "dimensions": {
           "width": 1080,
@@ -36,7 +36,7 @@
         },
         "alt": "foo bar",
         "copyright": null,
-        "url": "https://wroomdev.s3.amazonaws.com/tutoblanktemplate%2F97109f41-140e-4dc9-a2c8-96fb10f14051_star.gif"
+        "url": "https://wroomdev.s3.amazonaws.com/tutoblanktemplate%2F97109f41-140e-4dc9-a2c8-96fb10f14051_star.gif?auto=compress,format"
       }
     },
     "keyText": "key text",


### PR DESCRIPTION
There have been complaints about the quality of images being served by Prismic. There is no option in the Prismic UI to manage the compression they apply, so we can do it manually here instead.