### PR TITLE
Recursively fetch pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prismic-utils",
-  "version": "6.4.1",
+  "version": "6.4.2",
   "description": "A collection of functions for parsing data from a Prismic CMS",
   "main": "dist/index.js",
   "scripts": {

--- a/source/fetch/index.js
+++ b/source/fetch/index.js
@@ -5,22 +5,40 @@ const buildPredicates = (type, predicates = []) => (
 )
 
 export const fetchDocuments = ({
+  documents = [],
+  limit = 20,
   pageSize = 20,
+  page = 1,
   predicates, // https://prismic.io/docs/javascript/query-the-api/query-predicates-reference
   repository,
   token,
   type
 }) => (
   Prismic.getApi(`https://${repository}.cdn.prismic.io/api/v2`)
-  .then((api) => (
-    api.everything()
-    .ref(token || api.master())
-    .query(buildPredicates(type, predicates), {})
-    .pageSize(pageSize)
-    .submit()
-  )).then((response) => (
-    response.results
-  ))
+    .then((api) => (
+      api.everything()
+      .ref(token || api.master())
+      .query(buildPredicates(type, predicates), {})
+      .pageSize(pageSize)
+      .page(page)
+      .submit()
+    )).then((response) => {
+      const allDocs = [...documents, ...response.results]
+
+      if (allDocs.length < limit && response.next_page) {
+        return fetchDocuments({
+          documents: allDocs,
+          page: page + 1,
+          pageSize,
+          predicates,
+          repository,
+          token,
+          type
+        })
+      } else {
+        return allDocs
+      }
+    })
 )
 
 export const fetchDocument = (params) => (


### PR DESCRIPTION
Prismic has a hard limit of 100 documents per requst.

It now fetches recursively based on a limit param. I left the pageSize param separate as there were edge cases where it didn't really make sense.