### PR TITLE
add limit to fetch

### DIFF
--- a/source/fetch/index.js
+++ b/source/fetch/index.js
@@ -28,6 +28,7 @@ export const fetchDocuments = ({
       if (allDocs.length < limit && response.next_page) {
         return fetchDocuments({
           documents: allDocs,
+          limit,
           page: page + 1,
           pageSize,
           predicates,


### PR DESCRIPTION
Need to add limit param to recursive fetch, otherwise it gets reset to the default value. Have a project where we have 500+ docs, right now it will just fetch the first 200 hundred because the limit gets reset to 20 on the second fetch. Video showing what happens with update:
https://drive.google.com/file/d/12DnYfkxT08ScxFkQEGOoYdmZNkWXMACr/view
You can see with the console log added that the limit gets reset to 20.